### PR TITLE
feat(editor): Add highlight removal and update default color

### DIFF
--- a/components/editor/toolbar.tsx
+++ b/components/editor/toolbar.tsx
@@ -190,6 +190,11 @@ export function EditorToolbar({ editor }: Props) {
     editor.chain().focus().toggleHighlight({ color }).run();
   };
 
+  // Function to REMOVE the highlight
+  const removeBackgroundColor = () => {
+    editor.chain().focus().unsetHighlight().run();
+  };
+
   // Text alignment functions
   const setTextAlign = (alignment: "left" | "center" | "right" | "justify") => {
     editor.chain().focus().setTextAlign(alignment).run();
@@ -826,6 +831,7 @@ export function EditorToolbar({ editor }: Props) {
       </div>
 
       {/* Colors */}
+      {/* Colors */}
       <div className="flex items-center gap-2 pl-1">
         <label
           className="text-xs text-muted-foreground flex items-center gap-1"
@@ -852,12 +858,26 @@ export function EditorToolbar({ editor }: Props) {
         <input
           id="bg-color"
           type="color"
+          defaultValue="#FFFF00"
           onChange={(e) => setBackgroundColor(e.currentTarget.value)}
           className="h-8 w-8 cursor-pointer rounded border bg-background p-1"
           aria-label="Background color"
           title="Background color"
         />
+
+        {/* ✨ ADD THIS BUTTON */}
+        <button
+          type="button"
+          onClick={removeBackgroundColor}
+          className="p-1.5 rounded border"
+          aria-label="Remove highlight"
+          title="Remove highlight"
+        >
+          {/* You can replace this emoji with an icon component */}
+          🚫
+        </button>
       </div>
+
 
       {/* Find & Replace */}
       <div className="flex items-center gap-1">


### PR DESCRIPTION
### **Description**

Fixed #45 

This PR significantly improves the text highlighter functionality by addressing two key issues in the previous implementation:

1.  There was no way for a user to remove a highlight once it was applied.
2.  The default color for the highlighter was black (`#000000`), which is unintuitive and obscures text.

This update introduces a dedicated "Remove Highlight" button and changes the default highlighter color to a standard yellow (`#FFFF00`), aligning the feature with user expectations and standard text editor behavior.

### **Changes Made ✨**

* **Added Remove Highlight Button:** A new button has been added to the UI next to the color picker, allowing users to easily remove highlights from their selection.
* **Implemented `removeBackgroundColor` Logic:** A corresponding function was created that uses the Tiptap `unsetHighlight()` command to clear the formatting.
* **Updated Default Highlight Color:** The `<input type="color">` element for the highlighter now has its `defaultValue` set to `#FFFF00` (yellow), providing a much more sensible and user-friendly starting point.

### **How to Test 🧪**

**1. Verify the New Default Color:**
   - Open the text editor.
   - Click the highlight color picker icon.
   - **Expected:** The color picker should open with yellow (`#FFFF00`) selected by default.

**2. Verify the "Remove Highlight" Functionality:**
   - Select a piece of text in the editor.
   - Use the color picker to apply any highlight color.
   - Confirm the text is highlighted correctly.
   - With the text still selected, click the new "Remove Highlight" (🚫) button.
   - **Expected:** The highlight formatting should be completely removed, and the text should return to its normal state.