### PR TITLE
fix: document stats text cutoff issue on mobile

### DIFF
--- a/components/editor/status-bar.tsx
+++ b/components/editor/status-bar.tsx
@@ -76,26 +76,33 @@ export function StatusBar({ editor }: StatusBarProps) {
   if (!editor) return null
 
   return (
-    <div className="flex items-center justify-between px-4 py-2 bg-gray-50 dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700 text-sm text-gray-600 dark:text-gray-300">
+    <div className="w-full flex flex-col lg:flex-row items-center md:justify-between gap-y-2 lg:gap-y-0 px-4 py-2 bg-gray-50 dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700 text-sm text-gray-600 dark:text-gray-300">
       {/* Left side - Document stats */}
-      <div className="flex items-center gap-4">
-        <div className="flex items-center gap-1">
+      <div className="flex flex-wrap items-center justify-center gap-y-2 gap-x-4 md:gap-4">
+        <div className="flex items-center gap-1 text-blue-400">
           <FileText className="h-4 w-4" />
           <span className="font-medium">Document</span>
         </div>
+
         <div className="flex items-center gap-3">
           <span>{wordCount} words</span>
+        </div>
+
+        <div>
           {/* offset of -2 */}
           <span>{characterCount-2} characters</span>
+        </div>
+
+        <div>
           <span>{characterCountWhiteSpaces} characters excluding spaces</span>
         </div>
       </div>
 
       {/* Right side - Selection stats */}
-      <div className="flex items-center gap-4">
+      <div className="flex flex-wrap items-center justify-center gap-y-2 gap-x-4 md:gap-4">
         {selectedText.trim() && (
           <>
-            <div className="flex items-center gap-1">
+            <div className="flex items-center gap-1 text-green-400">
               <MousePointer className="h-4 w-4" />
               <span className="font-medium">Selected</span>
             </div>
@@ -107,7 +114,7 @@ export function StatusBar({ editor }: StatusBarProps) {
         )}
         
         {/* Cursor position indicator */}
-        <div className="flex items-center gap-1">
+        <div className="flex items-center justify-end gap-1">
           <Type className="h-4 w-4" />
           <span>Line {lineNumber}</span>
         </div>


### PR DESCRIPTION
Hello,

### Issue No. - #53

## Description
This PR fixes a UI issue where the "Document stats" section is displaying  
`Document 3 words 20 characters 19 characters excluding spaces`  
was being cut off on mobile screen sizes.  

The container width and text overflow have been adjusted to ensure all text is visible and properly aligned on smaller viewports.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally
- [ ] New tests added for new functionality
- [x] Manual testing completed  

**Manual Testing Steps:**
1. Open the editor on both desktop and mobile viewports.
2. Type a few words to trigger the document stats section.
3. Verify that the text (`3 words, 20 characters, 19 characters excluding spaces`) is fully visible and not clipped.

## Checklist
- [x] Code follows style guidelines
- [x] Self-review completed
- [ ] Documentation updated
- [x] No console errors

## Screenshot of the fixes
### Mobile
<img width="444" height="197" alt="Screenshot 2025-10-16 104259" src="https://github.com/user-attachments/assets/b431c17a-2d96-413c-953e-58f862981248" />

### Tablet
<img width="581" height="88" alt="Screenshot 2025-10-16 104309" src="https://github.com/user-attachments/assets/84cd38a8-6c85-4a2e-a27a-bd524b75ac65" />

### Laptop
<img width="1294" height="99" alt="Screenshot 2025-10-16 105151" src="https://github.com/user-attachments/assets/3606a2b5-0ba2-41f2-8cb7-fb59e857eb9f" />

---

Let me know if everything is correct.

Thank you.
