### PR TITLE
fix: Correct character count also by excluding newline characters

### DIFF
--- a/components/editor/status-bar.tsx
+++ b/components/editor/status-bar.tsx
@@ -40,8 +40,9 @@ export function StatusBar({ editor }: StatusBarProps) {
       const words = fullText.split(/\s+/).filter(word => word.length > 0)
       setWordCount(words.length)
       
-      // Count characters
-      setCharacterCount(fullText.length)
+
+      // Count characters excluding newlines
+      setCharacterCount(fullText.replace(/\n/g, '').length)
       
       // Get selected text
       const { from, to } = editor.state.selection
@@ -90,7 +91,7 @@ export function StatusBar({ editor }: StatusBarProps) {
 
         <div>
           {/* offset of -2 */}
-          <span>{characterCount-2} characters</span>
+          <span>{characterCount} characters</span>
         </div>
 
         <div>


### PR DESCRIPTION
## 🐛 Bug Fix: Character Count Logic

### Issue
Fixes #58 - Character count displays incorrect values and increases by 2 on newlines

### 📋 Problem Description
The status bar had character-counting issues:
1. When the editor was empty, it showed `-2 characters` due to a hardcoded offset
2. When pressing Enter to create a new line, the character count increased by 2 instead of staying the same
3. The previous solution used `{characterCount-2}`, which was a temporary workaround that didn't address the root cause

The root issue was that TipTap's `editor.getText()` includes newline characters (`\n`) in the count, which shouldn't be counted as visible characters.

### 🔧 Solution Implemented

**Changes in `status-bar.tsx`:**

1. **Fixed Character Count Calculation:**
```typescript
// Before:
setCharacterCount(fullText.length)

// After:
// Count characters excluding newlines
setCharacterCount(fullText.replace(/\n/g, '').length)
```

2. **Removed Hardcoded Offset:**
```typescript
// Before:
<span>{characterCount-2} characters</span>

// After:
<span>{characterCount} characters</span>
```

### ✅ Testing & Results

#### Before Fix:
- ❌ Empty editor: Shows `-2 characters`
- ❌ Pressing Enter: Character count increases by 2
- ❌ Inaccurate count due to newlines being included

#### After Fix:
- ✅ Empty editor: Shows `0 characters`
- ✅ Pressing Enter: Character count stays the same (newlines not counted)
- ✅ Spaces count as 1 character as expected
- ✅ Accurate character count across multiple lines
- ✅ All other counts (words, characters excluding spaces) work correctly


### 💡 Technical Details
The fix filters out newline characters (`\n`) from the character count using `.replace(/\n/g, '')`. This ensures that:
- Paragraph breaks don't artificially inflate the character count
- The count reflects only visible, typeable characters
- Users get an accurate representation of their content length

This approach is more robust than using hardcoded offsets and handles all edge cases properly.

### 🎃 Hacktoberfest 2025
This PR is part of Hacktoberfest 2025 contributions.

---

**Checklist:**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tested locally and verified the fix works
- [x] Code follows the project's style guidelines
- [x] No new warnings or errors introduced