### PR TITLE
Fix/70 Prevent empty editor export for PDF and Word 

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import './globals.css'
 import { ThemeProvider } from '@/components/theme-provider'
 import { Navbar } from '@/components/navbar'
 import { Footer } from '@/components/footer'
+import { Toaster } from "sonner"
 
 export const metadata: Metadata = {
   title: 'DocuEdit Pro - Professional Document Editor',
@@ -29,6 +30,7 @@ export default function RootLayout({
             <Navbar />
             <main className="flex-1">
               {children}
+               <Toaster /> 
             </main>
             <Footer />
           </div>

--- a/components/editor/toolbar.tsx
+++ b/components/editor/toolbar.tsx
@@ -63,6 +63,7 @@ import {
   RotateCcw,
 } from "lucide-react";
 import CustomColorPicker from '../ui/colorpicker'
+import { toast } from "sonner";
 
 type Props = {
   editor: Editor | null;
@@ -521,6 +522,26 @@ export function EditorToolbar({
   };
 
   const handleExportPDF = async () => {
+    // Get the HTML content
+    const htmlContent = editor.getHTML();
+    const textContent = editor.getText().trim();
+
+    // Check if it's the default initial content
+    const isDefaultContent =
+      htmlContent === "<h1>Welcome</h1><p>Start typing…</p>" ||
+      htmlContent === "<h1>Welcome</h1><p>Start typing...</p>" ||
+      textContent === "WelcomeStart typing…" ||
+      textContent === "WelcomeStart typing..." ||
+      textContent.length < 5;
+
+    if (editor.isEmpty || isDefaultContent) {
+      toast.error("Document is empty", {
+        description:
+          "Please add some content to the document before exporting to PDF.",
+      });
+      return;
+    }
+
     try {
       const element = editor.view.dom as HTMLElement;
       const opt = {
@@ -545,8 +566,14 @@ export function EditorToolbar({
       };
       const { default: html2PDF } = await import("jspdf-html2canvas-pro");
       await html2PDF(element, opt);
+      toast.success("PDF exported successfully", {
+        description: "Your document has been downloaded as PDF.",
+      });
     } catch (err) {
       console.error("[v0] Export PDF error:", err);
+      toast.error("Export failed", {
+        description: "An error occurred while exporting to PDF.",
+      });
     }
   };
 
@@ -568,30 +595,56 @@ export function EditorToolbar({
   };
 
   const handleExportWord = async () => {
+    // Get the HTML content
+    const htmlContent = editor.getHTML();
+    const textContent = editor.getText().trim();
+
+    // Check if it's the default initial content
+    const isDefaultContent =
+      htmlContent === "<h1>Welcome</h1><p>Start typing…</p>" ||
+      htmlContent === "<h1>Welcome</h1><p>Start typing...</p>" ||
+      textContent === "WelcomeStart typing…" ||
+      textContent === "WelcomeStart typing..." ||
+      textContent.length < 5;
+
+    if (editor.isEmpty || isDefaultContent) {
+      toast.error("Document is empty", {
+        description:
+          "Please add some content to the document before exporting to Word.",
+      });
+      return;
+    }
+
     try {
       const html = editor.getHTML();
       // Minimal Word-compatible HTML wrapper
       const docHtml = `
-<!DOCTYPE html>
-<html xmlns:o="urn:schemas-microsoft-com:office:office"
-      xmlns:w="urn:schemas-microsoft-com:office:word"
-      xmlns="http://www.w3.org/TR/REC-html40">
-  <head>
-    <meta charset="utf-8" />
-    <title>Document</title>
-    <style>
-      body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; }
-      h1,h2,h3,h4,h5 { line-height: 1.25; }
-      p { line-height: 1.5; }
-    </style>
-  </head>
-  <body>
-    ${html}
-  </body>
-</html>`;
+          <!DOCTYPE html>
+          <html xmlns:o="urn:schemas-microsoft-com:office:office"
+                xmlns:w="urn:schemas-microsoft-com:office:word"
+                xmlns="http://www.w3.org/TR/REC-html40">
+            <head>
+              <meta charset="utf-8" />
+              <title>Document</title>
+              <style>
+                body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; }
+                h1,h2,h3,h4,h5 { line-height: 1.25; }
+                p { line-height: 1.5; }
+              </style>
+            </head>
+            <body>
+              ${html}
+            </body>
+          </html>`;
       downloadBlob(docHtml, "document.doc", "application/msword");
+      toast.success("Word document exported successfully", {
+        description: "Your document has been downloaded as .doc file.",
+      });
     } catch (err) {
       console.error("[v0] Export Word (.doc) error:", err);
+      toast.error("Export failed", {
+        description: "An error occurred while exporting to Word.",
+      });
     }
   };
 


### PR DESCRIPTION
### Issue
Closes #70

Previously, users were able to download empty PDF or Word files when the editor contained only the default content (`<h1>Welcome</h1><p>Start typing…</p>`) or no content at all.

### Fix Implemented
- Added content validation before triggering export for both PDF and Word downloads.
- Checks for:
  - Default initial content (`<h1>Welcome</h1><p>Start typing…</p>`)
  - Very short documents (`textContent.length < 5`)
  - Empty editor state (`editor.isEmpty`)
- Displays a clear toast error message when attempting to export an empty document:
  - **PDF:** “Please add some content to the document before exporting to PDF.”
  - **Word:** “Please add some content to the document before exporting to Word.”

### Additional Improvements
- Added success and error toasts for both export functions to provide better user feedback.
- Improved error handling with console logging for debugging failed exports.

### Testing Steps
1. Open the editor with default or empty content.
2. Click on **Download PDF** or **Download Word**.
3. A toast error should appear, and no file should be downloaded.
4. Add any valid text or content.
5. Retry export — the file should download successfully with a success toast.

### 🎉 Additional Info
This pull request is part of **Hacktoberfest 2025**   
Contributing towards improving code quality and user experience across the editor features.

### Result
Users can no longer download blank or meaningless documents. This ensures better UX and prevents accidental empty exports.
