### PR TITLE
Add pages for documentation, help-center, contact us

### DIFF
--- a/app/contact-us/page.tsx
+++ b/app/contact-us/page.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+
+export default function ContactUs() {
+  return (
+    <main className="max-w-3xl mx-auto py-12 px-4 text-gray-200">
+      <h1 className="text-4xl font-bold mb-6 text-center">Contact Us</h1>
+      <p className="mb-8 text-lg text-center">
+        Have feedback, questions, or suggestions? The <strong>DocuEdit Pro Support Team</strong> is here to help.
+        Reach out to us through our community platforms, or use the form below to share your thoughts.
+      </p>
+
+      <section className="mb-10">
+        <h2 className="text-2xl font-semibold mb-3">1. Ways to Reach Us</h2>
+        <ul className="list-disc pl-6 space-y-2">
+          <li>
+            <strong>GitHub Discussions:</strong> Join our developer community to ask questions, share insights, or contribute to open-source development.
+          </li>
+          <li>
+            <strong>Feature Requests:</strong> Have an idea for improvement? Submit your suggestion through  <a href="https://github.com/amananandrai/document-editor-with-tiptap/issues" className="text-indigo-400 underline">Feature Request</a>.
+          </li>
+          <li>
+            <strong>Community Forum:</strong> Engage with other DocuEdit Pro users, explore guides, and troubleshoot issues together.
+          </li>
+          <li>
+            <strong>Documentation:</strong> Visit the <a href="/documentation" className="text-indigo-400 underline">Docs Page</a> for setup instructions and API references.
+          </li>
+        </ul>
+      </section>
+
+      <section className="mb-10">
+        <h2 className="text-2xl font-semibold mb-3">2. Feedback Form</h2>
+        <p className="mb-4">
+          We value your feedback! Please fill out the form below to share your suggestions, report issues, or request assistance.
+        </p>
+        <form className="space-y-4 bg-gray-900 p-6 rounded-2xl shadow-lg">
+          <div>
+            <label htmlFor="name" className="block mb-2 text-sm font-medium text-gray-300">
+              Name
+            </label>
+            <input
+              id="name"
+              type="text"
+              placeholder="Enter your name"
+              className="w-full p-3 rounded-lg bg-gray-800 border border-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="topic" className="block mb-2 text-sm font-medium text-gray-300">
+              Topic
+            </label>
+            <select
+              id="topic"
+              className="w-full p-3 rounded-lg bg-gray-800 border border-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            >
+              <option>General Feedback</option>
+              <option>Bug Report</option>
+              <option>Feature Request</option>
+              <option>Account or Access Issue</option>
+            </select>
+          </div>
+
+          <div>
+            <label htmlFor="message" className="block mb-2 text-sm font-medium text-gray-300">
+              Message
+            </label>
+            <textarea
+              id="message"
+              rows={4}
+              placeholder="Type your message here..."
+              className="w-full p-3 rounded-lg bg-gray-800 border border-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            ></textarea>
+          </div>
+
+          <button
+            type="submit"
+            className="w-full bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-3 rounded-lg transition duration-200"
+          >
+            Submit Feedback
+          </button>
+        </form>
+      </section>
+
+      <section>
+        <h2 className="text-2xl font-semibold mb-3">3. Response Time</h2>
+        <p className="mb-4">
+          Our support team aims to respond within <strong>24–48 hours</strong> on business days. Community discussions and GitHub
+          responses may take slightly longer depending on activity.
+        </p>
+        <p className="italic text-sm text-gray-400">
+          Tip: Before submitting a query, check the Help Center and Documentation — your question may already be answered there.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/app/documentation/page.tsx
+++ b/app/documentation/page.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+
+export default function Documentation() {
+  return (
+    <main className="max-w-3xl mx-auto py-12 px-4 text-gray-200">
+      <h1 className="text-4xl font-bold mb-6 text-center">Documentation</h1>
+      <p className="mb-8 text-lg text-center">
+        Welcome to the <strong>DocuEdit Pro Documentation</strong> — your complete guide to creating, editing, and exporting professional documents using our editor.
+        Whether you’re a developer integrating the editor or a writer exploring its tools, this documentation will help you get started quickly.
+      </p>
+
+      <section className="mb-10">
+        <h2 className="text-2xl font-semibold mb-3">1. Getting Started</h2>
+        <p className="mb-4">
+          To begin using DocuEdit Pro, install the dependencies and run the local development server. Once running, you’ll have access to a
+          feature-rich document editor built on <strong>React</strong>, <strong>TypeScript</strong>, and <strong>TipTap</strong>.
+        </p>
+        <pre className="bg-gray-900 text-gray-100 p-4 rounded-lg text-sm overflow-x-auto">
+{`npm install
+npm run dev`}
+        </pre>
+        <p className="mt-4">
+          After starting the development server, navigate to <code>http://localhost:3000</code> to open the editor in your browser.
+        </p>
+      </section>
+
+      <section className="mb-10">
+        <h2 className="text-2xl font-semibold mb-3">2. Editor Features</h2>
+        <ul className="list-disc pl-6 space-y-2">
+          <li>Rich text editing with headings, lists, tables, and code blocks.</li>
+          <li>Real-time formatting and auto-save functionality.</li>
+          <li>Keyboard shortcuts for quick navigation and editing.</li>
+          <li>Collaborative editing (coming soon).</li>
+        </ul>
+      </section>
+
+      <section className="mb-10">
+        <h2 className="text-2xl font-semibold mb-3">3. Customization</h2>
+        <p className="mb-4">
+          DocuEdit Pro supports deep customization through TipTap extensions. You can add your own formatting options, toolbar buttons, and themes.
+        </p>
+        <pre className="bg-gray-900 text-gray-100 p-4 rounded-lg text-sm overflow-x-auto">
+{`import { Extension } from '@tiptap/core'
+
+const Highlight = Extension.create({
+  name: 'highlight',
+  addOptions() {
+    return {
+      HTMLAttributes: { class: 'bg-yellow-300' },
+    }
+  },
+})`}
+        </pre>
+        <p className="mt-4">
+          Add your custom extension to the editor configuration to enable it globally.
+        </p>
+      </section>
+
+      <section className="mb-10">
+        <h2 className="text-2xl font-semibold mb-3">4. Exporting Documents</h2>
+        <p className="mb-4">
+          You can export documents directly to <strong>PDF</strong> or <strong>Word</strong> format. Click the <em>Export</em> button in the top toolbar, then choose your preferred format.
+        </p>
+        <ul className="list-disc pl-6 space-y-2">
+          <li>Export as PDF — maintains layout and formatting.</li>
+          <li>Export as DOCX — editable in Microsoft Word and Google Docs.</li>
+          <li>Supports multi-page layout and embedded images.</li>
+        </ul>
+      </section>
+
+      <section className="mb-10">
+        <h2 className="text-2xl font-semibold mb-3">5. Multi-Page Support</h2>
+        <p className="mb-4">
+          DocuEdit Pro provides seamless multi-page management. As your content grows, it automatically paginates the document.
+          You can also preview and reorder pages using the page navigation panel.
+        </p>
+        <ul className="list-disc pl-6 space-y-2">
+          <li>Auto-pagination as content expands.</li>
+          <li>Manual page breaks available in the toolbar.</li>
+          <li>Visual page indicators during editing and preview.</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2 className="text-2xl font-semibold mb-3">6. Developer Notes</h2>
+        <p className="mb-4">
+          The entire project is modular and open for extension. Follow best practices for TypeScript typing and component isolation
+          to keep your editor performant and scalable.
+        </p>
+        <p className="italic text-sm text-gray-400">
+          Tip: Always test your custom TipTap extensions separately before adding them to production.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/app/help-center/page.tsx
+++ b/app/help-center/page.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+
+export default function HelpCenter() {
+  return (
+    <main className="max-w-3xl mx-auto py-12 px-4 text-gray-200">
+      <h1 className="text-4xl font-bold mb-6 text-center">Help Center</h1>
+      <p className="mb-8 text-lg text-center">
+        Need assistance? The <strong>DocuEdit Pro Help Center</strong> provides answers to common questions, troubleshooting steps, and guidance for reporting issues or suggesting new features.
+      </p>
+
+      <section className="mb-10">
+        <h2 className="text-2xl font-semibold mb-3">1. Frequently Asked Questions (FAQ)</h2>
+        <ul className="list-disc pl-6 space-y-2">
+          <li>
+            <strong>How do I save my work?</strong><br />
+            DocuEdit Pro automatically saves your progress in real time. You can also manually click the <em>Save</em> button in the toolbar.
+          </li>
+          <li>
+            <strong>Can I use the editor offline?</strong><br />
+            Yes, DocuEdit Pro supports offline editing through local caching. Your changes will sync once you reconnect to the internet.
+          </li>
+          <li>
+            <strong>How do I export a document?</strong><br />
+            Use the <em>Export</em> button at the top right to download your document as a PDF or Word file.
+          </li>
+          <li>
+            <strong>Does the editor support collaboration?</strong><br />
+            Real-time collaboration is in active development and will be released in a future update.
+          </li>
+        </ul>
+      </section>
+
+      <section className="mb-10">
+        <h2 className="text-2xl font-semibold mb-3">2. Troubleshooting</h2>
+        <p className="mb-4">
+          Encountering an issue? Here are some quick tips to resolve common problems.
+        </p>
+        <ul className="list-disc pl-6 space-y-2">
+          <li>
+            <strong>Editor not loading properly:</strong> Clear your browser cache and refresh the page. Ensure you’re using the latest version of Chrome or Firefox.
+          </li>
+          <li>
+            <strong>Missing toolbar buttons:</strong> Go to <em>Settings → Toolbar Options</em> and re-enable any hidden features.
+          </li>
+          <li>
+            <strong>Export not working:</strong> Make sure you’ve granted file download permissions to your browser.
+          </li>
+          <li>
+            <strong>Fonts not displaying correctly:</strong> Verify that your system supports web fonts or try using a different font theme in settings.
+          </li>
+        </ul>
+      </section>
+
+      <section className="mb-10">
+        <h2 className="text-2xl font-semibold mb-3">3. Reporting a Bug</h2>
+        <p className="mb-4">
+          If you discover a bug or unexpected behavior, we appreciate your help in improving DocuEdit Pro. Please include the following details when reporting:
+        </p>
+        <ul className="list-disc pl-6 space-y-2">
+          <li>A clear description of the issue.</li>
+          <li>Steps to reproduce it (if possible).</li>
+          <li>Your operating system and browser version.</li>
+          <li>A screenshot or video recording (optional but helpful).</li>
+        </ul>
+        <p className="mt-4">
+          You can report issues via our <a href="https://github.com/amananandrai/document-editor-with-tiptap/issues" className="text-indigo-400 underline">GitHub Issues</a> page or send feedback directly from the in-app <em>Help → Report a Bug</em> option.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-2xl font-semibold mb-3">4. Feature Requests</h2>
+        <p className="mb-4">
+          We value your feedback! If there’s a feature you’d like to see in future versions, submit a request through our <a href="https://github.com/amananandrai/document-editor-with-tiptap/issues" className="text-indigo-400 underline">Feature Request Form</a>.
+        </p>
+        <ul className="list-disc pl-6 space-y-2">
+          <li>Provide a short summary of your idea.</li>
+          <li>Explain how it would improve your workflow.</li>
+          <li>Include any mockups or examples if available.</li>
+        </ul>
+        <p className="mt-4 italic text-sm text-gray-400">
+          Our team reviews all suggestions regularly and prioritizes features based on community votes.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -64,11 +64,11 @@ export function Footer() {
           <div>
             <h4 className="text-lg font-semibold mb-4">Support</h4>
             <ul className="space-y-2 text-gray-300">
-              <li><a href="#" className="hover:text-white transition-colors">Documentation</a></li>
-              <li><a href="#" className="hover:text-white transition-colors">Help Center</a></li>
-              <li><a href="#" className="hover:text-white transition-colors">Contact Us</a></li>
-              <li><a href="#" className="hover:text-white transition-colors">Bug Reports</a></li>
-              <li><a href="#" className="hover:text-white transition-colors">Feature Requests</a></li>
+              <li><a href="/documentation" className="hover:text-white transition-colors">Documentation</a></li>
+              <li><a href="/help-center" className="hover:text-white transition-colors">Help Center</a></li>
+              <li><a href="/contact-us" className="hover:text-white transition-colors">Contact Us</a></li>
+              <li><a href="https://github.com/amananandrai/document-editor-with-tiptap/issues" className="hover:text-white transition-colors">Bug Reports</a></li>
+              <li><a href="https://github.com/amananandrai/document-editor-with-tiptap/issues" className="hover:text-white transition-colors">Feature Requests</a></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
Added the pages on the website so that the user can have the idea of the website and the project.

Below are some screenshots of it:
<img width="1891" height="916" alt="image" src="https://github.com/user-attachments/assets/54a56699-9734-4f85-8001-85b31d0effab" />
<img width="1919" height="903" alt="image" src="https://github.com/user-attachments/assets/7f03dc9c-01a7-42d2-8d3f-e21f8ff5813f" />
<img width="1919" height="911" alt="image" src="https://github.com/user-attachments/assets/1347f8fb-347d-4462-95b6-4accc162267e" />
