### PR TITLE
Bug Fix: handleDrop function to remove visual feedback for drag over

### DIFF
--- a/components/editor/use-image-upload.ts
+++ b/components/editor/use-image-upload.ts
@@ -42,6 +42,12 @@ export function useImageUpload(editor: Editor | null) {
   const handleDrop = useCallback((event: React.DragEvent<HTMLDivElement>) => {
     event.preventDefault()
     
+    // Remove visual feedback for drag over    
+    const editorElement = editor?.view.dom as HTMLElement
+    if (editorElement) {
+      editorElement.classList.remove('drag-over')
+    }
+
     const files = event.dataTransfer?.files
     if (!files || files.length === 0) return
     
@@ -49,7 +55,7 @@ export function useImageUpload(editor: Editor | null) {
     Array.from(files).forEach(file => {
       handleImageUpload(file)
     })
-  }, [handleImageUpload])
+  }, [handleImageUpload, editor])
 
   const handleDragOver = useCallback((event: React.DragEvent<HTMLDivElement>) => {
     event.preventDefault()


### PR DESCRIPTION
# Fixed!

I analysed the [#130 Bug: The "Drop Image Here" pop-up doesn't dismiss](#130 ) and fixed it.

I request the maintainer to please add the "Hacktoberfest-accepted" label to this PR 😊

### Before:
<img width="1898" height="1091" alt="image" src="https://github.com/user-attachments/assets/9fcba020-2cc9-4524-8949-87a7c0c4c59e" />

### Changes done:
**1. Added the below code to `handleDrop` function in _use-image-upload.tsx_**

``` javascript
const editorElement = editor?.view.dom as HTMLElement
    if (editorElement) {
      editorElement.classList.remove('drag-over')
    }
```
