### PR TITLE
Just add cleanup to prevent overlapping operations.

### DIFF
--- a/components/editor/page-manager.tsx
+++ b/components/editor/page-manager.tsx
@@ -192,9 +192,12 @@ export function PageManagerProvider({
   React.useEffect(() => {
     if (editor && currentPage) {
       // Small delay to ensure editor is ready
-      setTimeout(() => {
+      const timeoutId = setTimeout(() => {
         editor.commands.setContent(currentPage.content);
       }, 50);
+      
+      // Cleanup: Cancel timeout if page changes again before timeout executes
+      return () => clearTimeout(timeoutId);
     }
   }, [currentPageIndex]); // Only depend on currentPageIndex, not currentPage object
 


### PR DESCRIPTION
What this does: 
Problem: Quick page navigation caused content from wrong pages to load 
Solution: clearTimeout() cancels the previous page load if user changes pages quickly
 Result: Always loads the correct page content, no more data corruption