### PR TITLE
[FIXED] Color Picker Dark Mode UI

### DIFF
--- a/components/ui/colorpicker.tsx
+++ b/components/ui/colorpicker.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState, useEffect, ReactNode } from "react";
 import { SketchPicker } from "react-color";
 
@@ -9,6 +11,25 @@ interface CustomColorPickerProps {
 
 export default function CustomColorPicker({ value, onChange, children }: CustomColorPickerProps) {
   const [color, setColor] = useState(value || "#000000");
+  const [isDark, setIsDark] = useState(false);
+
+  // Detect dark mode
+  useEffect(() => {
+    const checkDarkMode = () => {
+      setIsDark(document.documentElement.classList.contains('dark'));
+    };
+
+    checkDarkMode();
+
+    // Watch for theme changes
+    const observer = new MutationObserver(checkDarkMode);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class']
+    });
+
+    return () => observer.disconnect();
+  }, []);
 
   // Sync incoming prop only if it changed
   useEffect(() => {
@@ -39,25 +60,73 @@ export default function CustomColorPicker({ value, onChange, children }: CustomC
     onChange(transparentColor);
   };
 
+  // Dark mode color scheme matching light mode appearance
+  const darkModeStyles = isDark ? {
+    picker: {
+      boxShadow: 'none',
+      width: '280px',
+      backgroundColor: '#1e293b', // slate-800
+      padding: '10px 10px 0',
+      boxSizing: 'initial' as const,
+    },
+    saturation: {
+      borderRadius: '2px',
+    },
+    hue: {
+      borderRadius: '2px',
+    },
+    alpha: {
+      borderRadius: '2px',
+    },
+    input: {
+      width: '100%',
+      fontSize: '11px',
+      color: '#e2e8f0', // slate-200
+      background: '#334155', // slate-700
+      border: '1px solid #475569', // slate-600
+      borderRadius: '2px',
+      padding: '4px 10% 3px',
+      boxShadow: 'inset 0 0 0 1px #475569',
+    },
+    label: {
+      fontSize: '11px',
+      color: '#cbd5e1', // slate-300
+    },
+    controls: {
+      display: 'flex' as const,
+    },
+    activeColor: {
+      background: '#334155', // slate-700
+      borderRadius: '2px 2px 0 0',
+    },
+    color: {
+      background: '#334155', // slate-700
+      borderRadius: '2px',
+    },
+    swatch: {
+      background: '#334155', // slate-700
+    },
+  } : {
+    picker: {
+      boxShadow: 'none',
+      width: '280px',
+    },
+    input: {
+      width: '100%',
+      fontSize: '11px',
+    }
+  };
+
   return (
     <div className="relative">
-      <div className="bg-white rounded-md shadow-lg drop-shadow-xl">
+      <div className="bg-white dark:bg-slate-800 rounded-md shadow-lg drop-shadow-xl overflow-hidden">
         <SketchPicker
           color={color}
           onChange={handleChange}
           presetColors={presetColors}
           width="280px"
           styles={{
-            default: {
-              picker: {
-                boxShadow: 'none',
-                width: '280px',
-              },
-              input: {
-                width: '100%',
-                fontSize: '11px',
-              }
-            }
+            default: darkModeStyles
           }}
         />
         {children}


### PR DESCRIPTION
Before - #158  The Color Picker in dark mode was having complete UI of the light mode with small Bugs 
After - 
<img width="395" height="573" alt="image" src="https://github.com/user-attachments/assets/8f7d8009-7b11-4cb0-beb8-d5b9e1dfeac9" />
aligned the color picker perfectly with the Dark theme.