### PR TITLE
[codex] Fix Jest merge blockers

### DIFF
--- a/__tests__/components/ui/button.test.tsx
+++ b/__tests__/components/ui/button.test.tsx
@@ -24,7 +24,7 @@ describe('Button Component', () => {
   it('applies size classes correctly', () => {
     render(<Button size="sm">Small</Button>)
     const button = screen.getByRole('button')
-    expect(button).toHaveClass('h-9')
+    expect(button).toHaveClass('h-8')
   })
 
   it('can be disabled', () => {

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -36,25 +36,25 @@ const buttonVariants = cva(
   },
 )
 
-function Button({
-  className,
-  variant,
-  size,
-  asChild = false,
-  ...props
-}: React.ComponentProps<'button'> &
-  VariantProps<typeof buttonVariants> & {
-    asChild?: boolean
-  }) {
+const Button = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<'button'> &
+    VariantProps<typeof buttonVariants> & {
+      asChild?: boolean
+    }
+>(({ className, variant, size, asChild = false, ...props }, ref) => {
   const Comp = asChild ? Slot : 'button'
 
   return (
     <Comp
+      ref={ref}
       data-slot="button"
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />
   )
-}
+})
+
+Button.displayName = 'Button'
 
 export { Button, buttonVariants }

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,8 +9,12 @@ const createJestConfig = nextJest({
 const customJestConfig = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   testEnvironment: 'jsdom',
-  testPathIgnorePatterns: ['<rootDir>/.next/', '<rootDir>/node_modules/'],
-  moduleNameMapping: {
+  testPathIgnorePatterns: [
+    '<rootDir>/.next/',
+    '<rootDir>/node_modules/',
+    '<rootDir>/__tests__/setup/',
+  ],
+  moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
   },
   collectCoverageFrom: [


### PR DESCRIPTION
## What changed

This PR fixes the Jest issues that were blocking merge checks.

- corrected the Jest config key from `moduleNameMapping` to `moduleNameMapper`
- excluded `__tests__/setup/` from test-suite discovery so helper files are not treated as empty test suites
- updated `Button` to use `React.forwardRef`, which matches how the component is tested and used
- updated the button size assertion to match the current `sm` variant class (`h-8`)

## Why

The merge check failures were caused by test/config drift rather than application logic:

- Jest was warning on an invalid config key
- a helper-only file under `__tests__/setup/` was being picked up as a test suite and failing with "must contain at least one test"
- the button test expected ref forwarding and an outdated size class that no longer matched the component implementation

## Impact

- the Jest merge check should stop failing on config/setup issues
- button tests now reflect the actual button implementation
- ref behavior is now supported by the component instead of only being assumed by the test

## Validation

- ran `npm test -- --runInBand`
- result: `3` test suites passed, `25` tests passed, `0` failed

## Notes

This PR intentionally excludes unrelated local artifacts such as `package-lock.json` and `.codex-dev.*` logs.
