### PR TITLE
fix: preserve inline formatting styles on paste from external sources

### DIFF
--- a/components/editor/rich-editor.tsx
+++ b/components/editor/rich-editor.tsx
@@ -427,7 +427,51 @@ export function RichEditor() {
             // If the project doesn't include Typography plugin, this still renders fine
           ),
       },
+      // Preserve inline formatting styles (bold, italic, colors, font sizes, etc.)
+      // when pasting from external sources like Google Docs, Word, or web pages.
+      transformPastedHTML(html) {
+        // Parse the pasted HTML and allow key inline style properties through
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(html, "text/html");
+
+        // Walk all elements and keep allowed inline style properties
+        const allowedStyleProps = [
+          "font-family",
+          "font-size",
+          "font-weight",
+          "font-style",
+          "color",
+          "background-color",
+          "text-decoration",
+          "text-align",
+          "line-height",
+          "letter-spacing",
+        ];
+
+        doc.querySelectorAll("[style]").forEach((el) => {
+          const htmlEl = el as HTMLElement;
+          const existing = htmlEl.getAttribute("style") || "";
+          // Re-build style keeping only allowed props
+          const filtered = existing
+            .split(";")
+            .map((s) => s.trim())
+            .filter((s) => {
+              if (!s) return false;
+              const prop = s.split(":")[0]?.trim().toLowerCase();
+              return allowedStyleProps.some((allowed) => prop === allowed);
+            })
+            .join("; ");
+          if (filtered) {
+            htmlEl.setAttribute("style", filtered);
+          } else {
+            htmlEl.removeAttribute("style");
+          }
+        });
+
+        return doc.body.innerHTML;
+      },
     },
+
     content: `<h1>Welcome</h1><p>Start typing…</p>`,
     onCreate: ({ editor }) => {
       // Load saved content on editor creation

--- a/components/editor/use-image-upload.ts
+++ b/components/editor/use-image-upload.ts
@@ -79,16 +79,24 @@ export function useImageUpload(editor: Editor | null) {
     const items = event.clipboardData?.items
     if (!items) return
 
+    // Collect image file items only
+    const imageFiles: File[] = []
     Array.from(items).forEach(item => {
       if (item.type.startsWith('image/')) {
         const file = item.getAsFile()
-        if (file) {
-          event.preventDefault()
-          handleImageUpload(file)
-        }
+        if (file) imageFiles.push(file)
       }
     })
+
+    // Only intercept the paste event when there are real image files.
+    // For text/HTML pastes, let Tiptap's own paste handling run (including
+    // the transformPastedHTML hook that preserves formatting).
+    if (imageFiles.length === 0) return
+
+    event.preventDefault()
+    imageFiles.forEach(file => handleImageUpload(file))
   }, [handleImageUpload])
+
 
   return {
     handleDrop,


### PR DESCRIPTION
- Add transformPastedHTML to editorProps to allow font-family, font-size, color, background-color, text-decoration, text-align, line-height, and letter-spacing through Tiptap's HTML sanitization pass
- Fix handlePaste in use-image-upload to only call event.preventDefault() when pasting actual image files, so text/HTML pastes are always handled by Tiptap's own paste pipeline (including transformPastedHTML)

Fixes #87